### PR TITLE
UnitCounter bugfix and refactor

### DIFF
--- a/dm-tools/src/unit.rs
+++ b/dm-tools/src/unit.rs
@@ -170,25 +170,13 @@ where
         Ok(())
     }
 
-    // TODO Refactor
     pub fn set_from_text(&mut self, value: &str, unit: &T) -> Result<(), CountError> {
-        if value.starts_with('-') || value.starts_with('+') {
-            if let Ok(count) = value[1..].parse::<i64>() {
-                match value.chars().nth(0).unwrap() {
-                    '-' => self.sub_units(count, unit)?,
-                    '+' => self.add_units(count, unit)?,
-                    _ => unreachable!(),
-                };
-            } else {
-                return Err(CountError::InvalidValue);
+        match value.parse::<i64>() {
+            Ok(count) if value.starts_with('-') || value.starts_with('+') => {
+                self.add_units(count, unit)
             }
-        } else {
-            if let Ok(count) = value.parse::<i64>() {
-                self.set_units(count, unit)?;
-            } else {
-                return Err(CountError::InvalidValue);
-            }
+            Ok(count) => self.set_units(count, unit),
+            Err(_) => Err(CountError::InvalidValue),
         }
-        Ok(())
     }
 }

--- a/dm-tools/src/unit.rs
+++ b/dm-tools/src/unit.rs
@@ -134,7 +134,7 @@ where
     }
 
     pub fn redistribute(&mut self) -> Result<(), CountError> {
-        // Assumed `self.units` is sorted
+        // Assuming `self.units` is sorted
         let units = self.units.clone();
         for (i, unit) in units.iter().enumerate() {
             let count = self.get_count(&unit)?;
@@ -163,6 +163,7 @@ where
         Ok(())
     }
 
+    /// Set count for all `units` to 0.
     pub fn reset(&mut self, units: &[T]) -> Result<(), CountError> {
         for unit in units.iter() {
             self.set_units(0, unit)?;
@@ -170,6 +171,8 @@ where
         Ok(())
     }
 
+    /// Set count of `unit` from given string.
+    /// A leading '+' or '-' will add or subtract the count instead.
     pub fn set_from_text(&mut self, value: &str, unit: &T) -> Result<(), CountError> {
         match value.parse::<i64>() {
             Ok(count) if value.starts_with('-') || value.starts_with('+') => {


### PR DESCRIPTION
Calculations now use saturating operations to prevent overflow/underflow.